### PR TITLE
Setting concurrency to 4. Updating version to 0.1.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -110,6 +110,7 @@ export class PDIIIFDialog extends Component {
 
           // Start the PDF generation
           return await convertManifest(manifest, webWritable, {
+            concurrency: 4,
             maxWidth: 1500,
             coverPageEndpoint: "https://pdiiif.jbaiter.de/api/coverpage",
           });


### PR DESCRIPTION
**Setting concurrency to 4. Updating version to 0.1.4.**

---

**JIRA Ticket**: [(LTSVIEWER-183)](https://jira.huit.harvard.edu/browse/LTSVIEWER-183)

# What does this Pull Request do?

This updates the concurrency used in the pdiif convertManifest API call from 1 to 4. This significantly speeds up large downloads. This works together with [this Pull Request in mps-viewer](https://github.com/harvard-lts/mps-viewer/pull/43).

These changes have already been built to npmjs as **@harvard-lts/mirador-pdiiif-plugin 0.1.4**.

# How should this be tested?

A description of what steps someone could take to:

- This can be tested by rebuilding mps-viewer using this PR which updates mirador-pdiiif-plugin to 0.1.4, which uses the code in this PR.
- Please see the speed differences I experienced in [this JIRA comment](https://jira.huit.harvard.edu/browse/LTSVIEWER-183?focusedCommentId=634865&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-634865). You should see something similar.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz @jonw-cogapp @tristanr-cogapp @f8f8ff 
