### PR TITLE
Client-side PDF generation / download in FF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "pdiiif": "^0.1.0",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0"
+        "react-dom": "^16.14.0",
+        "streamsaver": "^2.0.6"
       },
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -10292,6 +10293,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsaver": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/streamsaver/-/streamsaver-2.0.6.tgz",
+      "integrity": "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        }
+      ]
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -18619,6 +18631,11 @@
       "requires": {
         "internal-slot": "^1.0.4"
       }
+    },
+    "streamsaver": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/streamsaver/-/streamsaver-2.0.6.tgz",
+      "integrity": "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pdiiif": "^0.1.0",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react-dom": "^16.14.0",
+    "streamsaver": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -136,6 +136,7 @@ export class PDIIIFDialog extends Component {
     const abortController = new AbortController();
 
     return await convertManifest(manifest.json, webWritable, {
+      concurrency: 4,
       maxWidth: 1500,
       abortController,
       coverPageEndpoint: "https://pdiiif.jbaiter.de/api/coverpage",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -25,6 +25,7 @@ const mapStateToProps = (state, { windowId, containerId }) => ({
   containerId: state.config.id,
   estimatedSize: state.PDIIIF[windowId]?.estimatedSizeInBytes,
   allowPdfDownload: state.PDIIIF[windowId]?.allowPdfDownload,
+  mitmPath: state.config.miradorPDIIIFPlugin.mitmPath,
 });
 
 /**
@@ -41,6 +42,13 @@ export class PDIIIFDialog extends Component {
       webWritable: null,
       abortController: new AbortController(), // Needs to be reset if aborted
     };
+  }
+
+  componentDidMount() {
+    const { mitmPath } = this.props;
+
+    // Set the streamsaver mitm path or allow default
+    streamSaver.mitm = mitmPath ?? streamSaver.mitm;
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -313,6 +321,7 @@ PDIIIFDialog.propTypes = {
   allowPdfDownload: PropTypes.bool,
   open: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
+  mitmPath: PropTypes.string,
 };
 
 PDIIIFDialog.defaultProps = {

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -65,15 +65,16 @@ export class PDIIIFDialog extends Component {
    * @param {Event} e
    */
   handleBeforeUnload = (e) => {
-    const { isDownloading } = this.state;
+    const { isDownloading, supportsFilesystemAPI } = this.state;
     // Unlike a regular download, if the user *closes* the window / tab
     // the download will fail, which is unexpected - this is just a warning
     // Most modern browsers also cannot show a custom message:
     // https://stackoverflow.com/questions/38879742/is-it-possible-to-display-a-custom-message-in-the-beforeunload-popup
     if (isDownloading && !supportsFilesystemAPI) {
+      const msg = "Are you sure? Leaving now will interrupt the download.";
       e.preventDefault();
-      return (e.returnValue =
-        "Are you sure? Leaving now will interrupt the download.");
+      e.returnValue = msg;
+      return msg;
     }
   };
 

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -9,6 +9,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import Typography from "@material-ui/core/Typography";
 import { convertManifest } from "pdiiif";
+import { formatBytes } from "../utils";
 
 const mapDispatchToProps = (dispatch, { windowId }) => ({
   closeDialog: () => dispatch({ type: "CLOSE_WINDOW_DIALOG", windowId }),
@@ -36,31 +37,6 @@ export class PDIIIFDialog extends Component {
       savingError: null,
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",
     };
-  }
-
-  /**
-   * Format bytes to human readable string
-   */
-  formatBytes(bytes, decimals = 2) {
-    if (!+bytes) return "0 Bytes";
-
-    const k = 1024;
-    const dm = decimals < 0 ? 0 : decimals;
-    const sizes = [
-      "Bytes",
-      "KiB",
-      "MiB",
-      "GiB",
-      "TiB",
-      "PiB",
-      "EiB",
-      "ZiB",
-      "YiB",
-    ];
-
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
   }
 
   /**
@@ -162,7 +138,7 @@ export class PDIIIFDialog extends Component {
             The file will appear in the directory you choose. <br />
             <br />
             {estimatedSize
-              ? ` (Estimated file size: ${this.formatBytes(estimatedSize)})`
+              ? ` (Estimated file size: ${formatBytes(estimatedSize)})`
               : ""}
           </DialogContentText>
         </DialogContent>

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -33,7 +33,6 @@ const mapStateToProps = (state, { windowId, containerId }) => ({
 export class PDIIIFDialog extends Component {
   constructor(props) {
     super(props);
-    this.props = props;
     this.state = {
       savingError: null,
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",

--- a/src/plugins/MiradorPDIIIFMenuItem.js
+++ b/src/plugins/MiradorPDIIIFMenuItem.js
@@ -7,6 +7,7 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import { withStyles } from "@material-ui/core/styles";
 import { getCanvasGroupings } from "mirador/dist/es/src/state/selectors";
 import { estimatePdfSize } from "pdiiif";
+import { checkStreamsaverSupport } from "../utils";
 
 // select an icon from material icons to import and use: https://v4.mui.com/components/material-icons/
 import PDFIcon from "@material-ui/icons/PictureAsPdf";
@@ -75,6 +76,7 @@ class PDIIIFMenuItem extends Component {
     this.state = {
       hasChecked: false,
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",
+      supportsStreamsaver: checkStreamsaverSupport(),
     };
   }
 
@@ -93,8 +95,11 @@ class PDIIIFMenuItem extends Component {
       allowPdfDownload,
       setEstimatedSize,
     } = this.props;
+    const { supportsFilesystemAPI, supportsStreamsaver } = this.state;
 
-    if (allowPdfDownload || !this.state.supportsFilesystemAPI) {
+    // If already allowed, don't check again
+    // Don't allow PDF download if neither Filesystem API or Streamsaver are supported
+    if (allowPdfDownload || (!supportsFilesystemAPI && !supportsStreamsaver)) {
       this.setState({ hasChecked: true });
       return;
     }

--- a/src/plugins/MiradorPDIIIFMenuItem.js
+++ b/src/plugins/MiradorPDIIIFMenuItem.js
@@ -7,7 +7,7 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import { withStyles } from "@material-ui/core/styles";
 import { getCanvasGroupings } from "mirador/dist/es/src/state/selectors";
 import { estimatePdfSize } from "pdiiif";
-import { checkStreamsaverSupport } from "../utils";
+import { checkImageApiHasCors, checkStreamsaverSupport } from "../utils";
 
 // select an icon from material icons to import and use: https://v4.mui.com/components/material-icons/
 import PDFIcon from "@material-ui/icons/PictureAsPdf";
@@ -77,6 +77,7 @@ class PDIIIFMenuItem extends Component {
       hasChecked: false,
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",
       supportsStreamsaver: checkStreamsaverSupport(),
+      imageApiHasCors: checkImageApiHasCors(),
     };
   }
 
@@ -95,11 +96,17 @@ class PDIIIFMenuItem extends Component {
       allowPdfDownload,
       setEstimatedSize,
     } = this.props;
-    const { supportsFilesystemAPI, supportsStreamsaver } = this.state;
+    const { supportsFilesystemAPI, supportsStreamsaver, imageApiHasCors } =
+      this.state;
 
     // If already allowed, don't check again
     // Don't allow PDF download if neither Filesystem API or Streamsaver are supported
-    if (allowPdfDownload || (!supportsFilesystemAPI && !supportsStreamsaver)) {
+    // Or if image API doesn't have CORS headers
+    if (
+      allowPdfDownload ||
+      (!supportsFilesystemAPI && !supportsStreamsaver) ||
+      !imageApiHasCors
+    ) {
       this.setState({ hasChecked: true });
       return;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,7 @@ export function checkStreamsaverSupport() {
  * Adapted from PDIIIF web example: https://github.com/jbaiter/pdiiif/blob/main/pdiiif-web/src/iiif.ts
  * @returns {boolean} true if image API has CORS
  */
-export async function imageApiHasCors() {
+export async function checkImageApiHasCors() {
   try {
     let testImgResp = await fetch(images[0]["@id"] ?? images[0].id);
     let testImgData = new Uint8Array(await testImgResp.arrayBuffer());

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,60 @@
+/**
+ * Format bytes to human readable string
+ * https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+ * @param {number} bytes number of bytes
+ * @param {number} decimals number of decimals
+ * @returns {string} human readable string
+ */
+export function formatBytes(bytes, decimals = 2) {
+  if (!+bytes) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = [
+    "Bytes",
+    "KiB",
+    "MiB",
+    "GiB",
+    "TiB",
+    "PiB",
+    "EiB",
+    "ZiB",
+    "YiB",
+  ];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+/**
+ * Check support for streamsaver
+ * Adapted from PDIIIF web example: https://github.com/jbaiter/pdiiif/blob/main/pdiiif-web/src/util.ts
+ */
+export function supportsStreamsaver() {
+  try {
+    // Our usecase requires WriteableStream
+    new Response(new WritableStream());
+    if (isSecureContext && !("serviceWorker" in navigator)) {
+      return false;
+    }
+  } catch (err) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Check image API has CORS
+ * Adapted from PDIIIF web example: https://github.com/jbaiter/pdiiif/blob/main/pdiiif-web/src/iiif.ts
+ * @returns {boolean} true if image API has CORS
+ */
+export async function imageApiHasCors() {
+  try {
+    let testImgResp = await fetch(images[0]["@id"] ?? images[0].id);
+    let testImgData = new Uint8Array(await testImgResp.arrayBuffer());
+    return testImgData[0] !== undefined ? true : false;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ export function formatBytes(bytes, decimals = 2) {
  * Check support for streamsaver
  * Adapted from PDIIIF web example: https://github.com/jbaiter/pdiiif/blob/main/pdiiif-web/src/util.ts
  */
-export function supportsStreamsaver() {
+export function checkStreamsaverSupport() {
   try {
     // Our usecase requires WriteableStream
     new Response(new WritableStream());


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-172](https://jira.huit.harvard.edu/browse/LTSVIEWER-172)

# What does this Pull Request do?

Updates the plugin to detect a lack of support for the Filesystem API and provide a new mechanism for downloading in those browsers using [streamsaver](https://www.npmjs.com/package/streamsaver).

# How should this be tested?

## Setup locally
- Check out [the companion PR](https://github.com/harvard-lts/mps-viewer/pull/44) in mps-viewer. You should stop and restart the container as a quick / safe way to get it to install the dependencies and run webpack

## Testing in Chrome
- Attempting to download a PDF from any of the legacy IDS examples should work the same way it did previously using the Filesystem API.

## Testing in Firefox
- Attempting to download a PDF from any of the legacy IDS examples should now work, previously it did not.
- You should find that if you try to close the tab / window while the download is in progress you'll be met by a dialog box *
  - Clicking cancel to stay should allow the download to finish unless something else goes wrong (e.g. the 500 server error)
  - Clicking to leave anyway will effectively stop the download, but the transfer will appear as in progress, until manually cancelled.
- Cancelling an in-progress download from the browser UI will stop the download, and remove the temporary files
 
*This is to attempt to circumvent a quirk of streamsaver which is the tab must be kept open for the duration of the download otherwise it will fail silently and appear to be in progress. It should be noted that:

a) We cannot change the text of this dialog
b) As we can't guarantee the browser will run our `beforeunload`/`unload` code that — it's likely partial files will be left behind unless manually cancelled.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests?  No
- integration tests? No

# Interested parties

@enriquediaz 
