### PR TITLE
Add page selection functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -7,6 +7,7 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
+import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import { convertManifest } from "pdiiif";
 
@@ -35,6 +36,7 @@ export class PDIIIFDialog extends Component {
     this.state = {
       savingError: null,
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",
+      pages: '',
     };
   }
 
@@ -64,13 +66,13 @@ export class PDIIIFDialog extends Component {
   }
 
   /**
-   * Downoloads the PDF
+   * Downloads the PDF
    */
   downloadPDF = async () => {
     const { manifest, closeDialog } = this.props;
-    const { supportsFilesystemAPI } = this.state;
+    const { supportsFilesystemAPI, pages } = this.state;
     // Get a writable handle to a file on the user's machine
-
+    
     let handle;
 
     // TODO: fully handle Firefox / server side generation with streams
@@ -109,9 +111,13 @@ export class PDIIIFDialog extends Component {
           closeDialog();
 
           // Start the PDF generation
+          console.log('PAGES:');
+          console.log(pages);
           return await convertManifest(manifest, webWritable, {
             maxWidth: 1500,
             coverPageEndpoint: "https://pdiiif.jbaiter.de/api/coverpage",
+            //filterCanvases: [pages],
+            //filterCanvases: ['https://ids.lib.harvard.edu/ids/iiif/4997395/full/full/0/default.jpg'],
           });
         }
       } catch (e) {
@@ -164,6 +170,15 @@ export class PDIIIFDialog extends Component {
               ? ` (Estimated file size: ${this.formatBytes(estimatedSize)})`
               : ""}
           </DialogContentText>
+          <TextField
+            id="pages"
+            label="Pages"
+            margin="normal"
+            variant="outlined"
+            placeholder="1, 4, 8-12, ..."
+            onChange={(event) => this.setState({ pages : event.target.value })}
+            
+          />
         </DialogContent>
         <DialogActions>
           <Button onClick={this.downloadPDF} color="primary">

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -277,7 +277,7 @@ export class PDIIIFDialog extends Component {
         <DialogActions>
           <Button
             onClick={this.downloadPDF}
-            className={pageError && classes.disabledButton}
+            className={pageError ? classes.disabledButton : ""}
             color="primary"
             disabled={pageError}
           >
@@ -295,6 +295,17 @@ export class PDIIIFDialog extends Component {
 PDIIIFDialog.defaultProps = {
   canvases: [],
   open: false,
+};
+
+PDIIIFDialog.propTypes = {
+  allowPdfDownload: PropTypes.bool.isRequired,
+  canvasIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  closeDialog: PropTypes.func.isRequired,
+  containerId: PropTypes.string.isRequired,
+  estimatedSize: PropTypes.number,
+  manifest: PropTypes.object.isRequired,
+  open: PropTypes.bool,
 };
 
 const styles = () => ({

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -47,17 +47,7 @@ function formatBytes(bytes, decimals = 2) {
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = [
-    "Bytes",
-    "KiB",
-    "MiB",
-    "GiB",
-    "TiB",
-    "PiB",
-    "EiB",
-    "ZiB",
-    "YiB",
-  ];
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
@@ -233,6 +223,10 @@ export class PDIIIFDialog extends Component {
 
     if (!open || !allowPdfDownload) null;
 
+    const fileSizeText = estimatedSize
+      ? ` and has an estimated file size of ${formatBytes(estimatedSize)}`
+      : "";
+
     return (
       <Dialog
         container={document.querySelector(`#${containerId} .mirador-viewer`)}
@@ -253,16 +247,11 @@ export class PDIIIFDialog extends Component {
           <DialogContentText>
             Download a PDF of the current document?
             <br />
-            The file will appear in the directory you choose. <br />
             <br />
-            {estimatedSize
-              ? ` (Estimated file size: ${formatBytes(estimatedSize)})`
-              : ""}
-            <br />
-            <br />
-            The source document contains {canvasIds.length} pages. All pages
-            will be included by default. Optionally you may provide a comma
-            separated list of pages and/or ranges.
+            The document contains {canvasIds.length} pages{fileSizeText}. All
+            pages will be included by default. If you wish to download certain
+            portions of it, you may provide a comma separated list of pages
+            and/or ranges.
           </DialogContentText>
           <TextField
             id="pages"

--- a/tests/MiradorPDIIIFDialog.test.js
+++ b/tests/MiradorPDIIIFDialog.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor, screen } from "@testing-library/react";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import { MiradorPDIIIFDialogPlugin } from "../src";
 import "@testing-library/jest-dom";
 
@@ -7,7 +7,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe("PDF menu item", () => {
+describe("PDF dialog", () => {
   it("Should not render if allowPdfDownload is false ", async () => {
     render(
       <MiradorPDIIIFDialogPlugin.component
@@ -21,6 +21,7 @@ describe("PDF menu item", () => {
         manifest={{}}
         manifestId="abc123"
         allowPdfDownload={false}
+        canvasIds={["canvas1", "canvas2", "canvas3"]}
         windowId="abc123"
       />
     );
@@ -44,6 +45,7 @@ describe("PDF menu item", () => {
         manifestId="abc123"
         open={true}
         allowPdfDownload={true}
+        canvasIds={["canvas1", "canvas2", "canvas3"]}
         windowId="abc123"
       />
     );
@@ -51,5 +53,81 @@ describe("PDF menu item", () => {
     const button = screen.queryByText("Download");
     expect(title).toBeInTheDocument();
     expect(button).toBeInTheDocument();
+  });
+
+  it("Should disable download if pages aren't in range", async () => {
+    render(
+      <MiradorPDIIIFDialogPlugin.component
+        classes={{
+          h2: "h2",
+          h3: "h3",
+          disabledButton: "disabledButton",
+        }}
+        closeDialog={() => {}}
+        containerId="mirador-container"
+        estimatedSize={100000}
+        manifest={{}}
+        manifestId="abc123"
+        open={true}
+        allowPdfDownload={true}
+        canvasIds={[
+          "canvas1",
+          "canvas2",
+          "canvas3",
+          "canvas4",
+          "canvas5",
+          "canvas6",
+          "canvas7",
+          "canvas8",
+          "canvas9",
+          "canvas10",
+        ]}
+        windowId="abc123"
+      />
+    );
+    const title = screen.queryByText("PDF Download");
+    const button = screen.queryByText("Download").parentElement;
+    const input = screen.queryByPlaceholderText("1, 4, 8-12, ...");
+    fireEvent.change(input, { target: { value: "1,2,3-6,7,9-12" } });
+    expect(title).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it("Should allow download if pages are in range", async () => {
+    render(
+      <MiradorPDIIIFDialogPlugin.component
+        classes={{
+          h2: "h2",
+          h3: "h3",
+          disabledButton: "disabledButton",
+        }}
+        closeDialog={() => {}}
+        containerId="mirador-container"
+        estimatedSize={100000}
+        manifest={{}}
+        manifestId="abc123"
+        open={true}
+        allowPdfDownload={true}
+        canvasIds={[
+          "canvas1",
+          "canvas2",
+          "canvas3",
+          "canvas4",
+          "canvas5",
+          "canvas6",
+          "canvas7",
+          "canvas8",
+          "canvas9",
+          "canvas10",
+        ]}
+        windowId="abc123"
+      />
+    );
+    const title = screen.queryByText("PDF Download");
+    const button = screen.queryByText("Download").parentElement;
+    const input = screen.queryByPlaceholderText("1, 4, 8-12, ...");
+    fireEvent.change(input, { target: { value: "3-6,10" } });
+    expect(title).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-160](https://jira.huit.harvard.edu/browse/LTSVIEWER-160)

- [Companion PR]()

# What does this Pull Request do?

Allows the user to input specific pages and / or ranges of page to include in the PDF

# How should this be tested?

**Note: this can currently only be tested on legacy IDS manifests**

- Checkout MPS viewer locally from the companion PR branch
- Restart your local MPS viewer docker container
- It should install the latest version of the PDIIIF plugin and run webpack automatically
- Go to the MPS viewer main page and select a legacy PTO
- Accessing PDIIIF from the plugin menu there should be an input
- Try to download a PDF without entering anything into the text box. By default no range being entered should download the full document
- Entering these value should work and give a PDF with corresponding pages (N.B. keep track of the numbers you choose here):
  - A single page number
  - A range (e.g. 2-3)
  - A comma separated list of pages (e.g. 1,2,3)
  - A comma separated list of pages and ranges (e.g.1, 3-5, 8, 9-14)
- Entering these values should trigger the validation and prevent download:
  - 0
  - A negative number
  - A number bigger than the size of the document
- Other Non-parsable values (e.g. horse) should just result in all pages being included


# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? Yes
- integration tests? No

# Interested parties

@enriquediaz 
