### PR TITLE
Add configurable coverpage API endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.17",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.15",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -33,6 +33,7 @@ const mapStateToProps = (state, { windowId }) => ({
   canvasIds: getCanvases(state, { windowId }).map((canvas) => canvas.id),
   mitmPath: state.config.miradorPDIIIFPlugin.mitmPath,
   manifestLabel: getManifestTitle(state, { windowId }),
+  coverPageEndpoint: state.config.miradorPDIIIFPlugin.coverPageEndpoint,
 });
 
 /**
@@ -351,7 +352,7 @@ export class PDIIIFDialog extends Component {
    * @returns {Promise} (implicit)
    */
   async manifestConverter(webWritable) {
-    const { manifest } = this.props;
+    const { manifest, coverPageEndpoint } = this.props;
     const { abortController, filteredCanvasIds } = this.state;
 
     this.attachAbortListener();
@@ -363,7 +364,8 @@ export class PDIIIFDialog extends Component {
       maxWidth: 1500,
       abortController,
       filterCanvases: filteredCanvasIds,
-      coverPageEndpoint: "https://pdiiif.jbaiter.de/api/coverpage",
+      coverPageEndpoint:
+        coverPageEndpoint ?? "https://pdiiif.jbaiter.de/api/coverpage",
     });
 
     this.setState({ isDownloading: false });
@@ -454,6 +456,7 @@ PDIIIFDialog.propTypes = {
   }).isRequired,
   closeDialog: PropTypes.func.isRequired,
   containerId: PropTypes.string.isRequired,
+  coverPageEndpoint: PropTypes.string,
   estimatedSize: PropTypes.number,
   manifest: PropTypes.object,
   manifestId: PropTypes.string,


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-158](https://jira.huit.harvard.edu/browse/LTSVIEWER-158)

- [Harvard LTS PDIIIF companion PR](https://github.com/harvard-lts/pdiiif/pull/1)
- [mps-viewer companion PR](https://github.com/harvard-lts/mps-viewer/pull/54)

# What does this Pull Request do?
Replace hard coded URL with config option for the coverpage API endpoint. Will fallback to public API if not provided.

# How should this be tested?

- Refer to the testing instructions in the Harvard [LTS PDIIIF repository](https://github.com/harvard-lts/pdiiif/pull/1)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 