### PR TITLE
Bugfix ltsviewer 197

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.17",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.17",
+  "version": "0.1.19",
   "description": "mirador-pdiiif-plugin React component",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -258,7 +258,7 @@ export class PDIIIFDialog extends Component {
     }
 
     // Enforce character limit (arbitrary)
-    suggestedName = `${suggestedName.slice(0, 256)}.pdf`;
+    suggestedName = `${suggestedName.slice(0, 128)}.pdf`;
 
     // Ensure fresh state on each download attempt
     this.resetDownloadState();

--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -257,8 +257,8 @@ export class PDIIIFDialog extends Component {
       suggestedName = `PDF Download ${date.getYear()}-${date.getMonth()}-${date.getDate()}`;
     }
 
-    // Enforce character limit (arbitrary)
-    suggestedName = `${suggestedName.slice(0, 128)}.pdf`;
+    // Enforce character limit (arbitrary, 128 incl extension)
+    suggestedName = `${suggestedName.slice(0, 123)}.pdf`;
 
     // Ensure fresh state on each download attempt
     this.resetDownloadState();


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-197](https://jira.huit.harvard.edu/browse/LTSVIEWER-197)

- [mps-viewer companion PR](https://github.com/harvard-lts/mps-viewer/pull/55)

# What does this Pull Request do?

By agreement we're lowering the character limit for file names to 128, as ~256 causes problems in some scenarios.

# How should this be tested?

- Checkout mps-viewer on the companion PR branch
- Restart the container to have it install the new dependency and build the assets
- Visit this page: `https://localhost:23017/viewer/?manifestId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fdrs%3A2573759&canvasId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fdrs%3A2573759%2Fcanvas%2Fcanvas-1410363.json`
- Download a copy of this PDF, copy the file name and check it's length in a text editor or [some kind of online tool](https://charactercalculator.com/), including the file extension we expect this to be no longer than 128 characters

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No
