### PR TITLE
Removing coverpage fallback.

### DIFF
--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -428,8 +428,7 @@ export class PDIIIFDialog extends Component {
           maxWidth: 1500,
           abortController,
           filterCanvases: filteredCanvasIds,
-          coverPageEndpoint:
-            coverPageEndpoint ?? "https://pdiiif.jbaiter.de/api/coverpage",
+          coverPageEndpoint: coverPageEndpoint ?? "",
           onProgress: this.updateProgress,
         });
       } catch (e) {


### PR DESCRIPTION
**Removing coverpage fallback.**

---

**JIRA Ticket**: [LTSVIEWER-259](https://jira.huit.harvard.edu/browse/LTSVIEWER-259)

# What does this Pull Request do?

This removes the fallback in the plugin that uses https://pdiiif.jbaiter.de/ if you do not pass in a coverpage endpoint. The default option will now be that no coverpage is generated.

# How should this be tested?

A description of what steps someone could take to:

- Pull in the latest code from the `LTSVIEWER-259 branch`
- Run the command `npm run clean`
- Run the command `npm run build`
- Run the command `npm run serve`
- Open the running application in GOOGLE CHROME at: http://localhost:9000/
- Click the three dots at the top right of Mirador Viewer and click "Download PDF."
- Confirm that the PDF generated does not have a cover page.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@f8f8ff 
