### PR TITLE
Fixing PDF Download showing 0 bytes for any object's file size

### DIFF
--- a/src/plugins/MiradorPDIIIFMenuItem.js
+++ b/src/plugins/MiradorPDIIIFMenuItem.js
@@ -44,11 +44,21 @@ const PDIIIFReducer = (state = {}, action) => {
     };
   }
   if (action.type === "PDIIIF/SET_ESTIMATED_SIZE") {
+    var estimatedSizeInBytes = action.size;
+    if (
+      typeof action.size === 'object' &&
+      !Array.isArray(action.size) &&
+      action.size !== null
+    ) {
+        if ('size' in action.size) {
+          estimatedSizeInBytes = action.size.size;
+        }
+    }
     return {
       ...state,
       [action.windowId]: {
         ...state[action.windowId],
-        estimatedSizeInBytes: action.size,
+        estimatedSizeInBytes: estimatedSizeInBytes,
       },
     };
   }


### PR DESCRIPTION
**Fixing PDF Download showing 0 bytes for any object's file size.**

---

**JIRA Ticket**: [LTSVIEWER-270](https://jira.huit.harvard.edu/browse/LTSVIEWER-270)

# What does this Pull Request do?

The PDF Download dialog box shows 0 bytes, because the plugin is expecting a number, but in `mps-viewer` it is actually getting an object. The object looks like this:
`Object { size: 502949479.7601479, corsSupported: true }`

For me, the plugin on its own displays the proper bytes before making any changes. I suspect that the change has something to do with the version of Node that is used. So I've updated the plugin code to handle both cases that way it'll work for a larger set of potential plugin users.

# How should this be tested?

A description of what steps someone could take to:

- Confirm it is still working in the plugin itself:
  - Pull in the latest `mirador-pfiiif-plugin` code from the `LTSVIEWER-270` branch.
  - run `npm run serve`
  - Confirm that the bytes show up in the example item that appears ("Hot Dog In A Manger")
- Confirm it is working in mps-viewer:
  - in your local version of `mirador-pdiiif-plugin` run `npm run build` This will create a new `index.js` file in the `/dist/es` folder.
  - Copy that `index.js` file into a new folder `/plugins/pdiiif` in your local version of `mps-viewer`
- Update line 7 of the `/src/mirador.js` file in `mps-viewer` to: `import miradorPdiiifPlugin from '../plugins/pdiiif';` (You can use any branch. This will not be committed to the `mps-viewer` repo.)
- Rebuild your local `mps-embed` and `mps-viewer` containers
- Confirm that the bytes are showing up properly for all examples in `mps-viewer`.

Once this is confirmed to be working, I will tag and deploy a new release of `mirador-pdiiif-plugin` to NPM. Then I will create a new PR for `mps-viewer` that will use the new `mirador-pdiiif-plugin` release. 

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz @f8f8ff 
