### PR TITLE
Align "Done" button and page range input behaviours

### DIFF
--- a/src/plugins/MiradorPDIIIFDialog.js
+++ b/src/plugins/MiradorPDIIIFDialog.js
@@ -495,7 +495,7 @@ export class PDIIIFDialog extends Component {
             error={pageError}
             onChange={this.handlePageChange}
             value={this.state.indexSpec}
-            disabled={isDownloading}
+            disabled={isDownloading || progress === 100}
           />
           {this.renderProgress()}
         </DialogContent>


### PR DESCRIPTION
**Align "Done" button and page range input behaviours**

---

**JIRA Ticket**: [LTSVIEWER-227](https://jira.huit.harvard.edu/browse/LTSVIEWER-227)

# What does this Pull Request do?
Disables page range input field when download is complete

# How should this be tested?

* Spin up the demo site from this branch: `npm run serve`
* Open the "Download PDF" modal window (a dropdown option under the three dots in the top right of viewer)
* Begin a download and confirm that the page range input field is disabled both during the download and after the download has completed
* Close the modal window and reopen it
* Confirm that the page range input field is enabled again


# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 
