### PR TITLE
LTSVIEWER-366 No Restricted Downloads

### DIFF
--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -14,6 +14,10 @@ document.addEventListener("DOMContentLoaded", () => {
       {
         manifestId: "https://nrs.harvard.edu/URN-3:FHCL.LOEB:25853480:MANIFEST:3",
       },
+      {
+        manifestId: "https://nrs.harvard.edu/URN-3:FHCL.HOUGH:105813588:MANIFEST:3",
+      },
+      
     ],
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "react-component"
   ],
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "mirador-pdiiif-plugin React component",
   "module": "dist/es/index.js",
   "files": [

--- a/src/plugins/MiradorPDIIIFMenuItem.js
+++ b/src/plugins/MiradorPDIIIFMenuItem.js
@@ -6,7 +6,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { withStyles } from "@material-ui/core/styles";
 import { estimatePdfSize } from "pdiiif";
-import { checkImageApiHasCors, checkStreamsaverSupport } from "../utils";
+import { checkImageApiHasCors, checkStreamsaverSupport, checkObjectPublic } from "../utils";
 
 // select an icon from material icons to import and use: https://v4.mui.com/components/material-icons/
 import PDFIcon from "@material-ui/icons/PictureAsPdf";
@@ -86,6 +86,7 @@ class PDIIIFMenuItem extends Component {
       supportsFilesystemAPI: typeof showSaveFilePicker === "function",
       supportsStreamsaver: checkStreamsaverSupport(),
       imageApiHasCors: checkImageApiHasCors(),
+      objectPublic: false, // Will be set in componentDidMount
     };
   }
 
@@ -119,6 +120,12 @@ class PDIIIFMenuItem extends Component {
     }
 
     if (!manifest?.error && manifest?.json) {
+      console.log('MANIFEST LOADED, CHECKING IF PTO AND PUBLIC!!!');
+      
+      // Check if object is public
+      const objectPublic = await checkObjectPublic(manifest.json);
+      console.log('objectPublic:', objectPublic);
+      
       let isPTO = false;
       if (manifest.json.structures && manifest.json.structures.length > 0) {
         if (manifest.json.structures[0]['@type'] == 'sc:Range' || manifest.json.structures[0].type == 'Range') {
@@ -126,7 +133,7 @@ class PDIIIFMenuItem extends Component {
         }
       }
       // Only show PDF's for PTO's
-      if (isPTO) {
+      if (isPTO && objectPublic) {
         // Check size can be estimated
         const estimatedSizeInBytes = await estimatePdfSize({
           manifest: manifest.json,

--- a/src/plugins/MiradorPDIIIFMenuItem.js
+++ b/src/plugins/MiradorPDIIIFMenuItem.js
@@ -120,11 +120,8 @@ class PDIIIFMenuItem extends Component {
     }
 
     if (!manifest?.error && manifest?.json) {
-      console.log('MANIFEST LOADED, CHECKING IF PTO AND PUBLIC!!!');
-      
       // Check if object is public
       const objectPublic = await checkObjectPublic(manifest.json);
-      console.log('objectPublic:', objectPublic);
       
       let isPTO = false;
       if (manifest.json.structures && manifest.json.structures.length > 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,23 +55,22 @@ export async function checkImageApiHasCors() {
  * @returns {boolean} true if object is public
  */
 export async function checkObjectPublic(manifest) {
-  console.log('CHECKING IF OBJECT IS PUBLIC!!!!');
   try {
     // Get the first canvas from the manifest
     if (!manifest || !manifest.items || manifest.items.length === 0) {
-      console.log('No items found in manifest, returning false');
+      // No items found in manifest, returning false
       return false;
     }
     
     const firstCanvas = manifest.items[0];
     if (!firstCanvas.items || firstCanvas.items.length === 0) {
-      console.log('No items found in first canvas, returning false');
+      // No items found in first canvas, returning false
       return false;
     }
     
     const firstAnnotationPage = firstCanvas.items[0];
     if (!firstAnnotationPage.items || firstAnnotationPage.items.length === 0) {
-      console.log('No items found in first annotation page, returning false');
+      // No items found in first annotation page, returning false
       return false;
     }
     
@@ -79,20 +78,22 @@ export async function checkObjectPublic(manifest) {
     const imageUrl = firstAnnotation.body.id || firstAnnotation.body['@id'];
     
     if (!imageUrl) {
-      console.log('No image URL found, returning false');
+      // No image URL found, returning false
       return false;
     }
     
     let testImgResp = await fetch(imageUrl);
     console.log("testImgResp.status", testImgResp.status);
     if (testImgResp.status == 403 || testImgResp.status == 401) {
+      // Response indicates restricted access, returning false
       return false;
     }
     else { 
+      // Otherwise assume public, returning true
       return true; 
     };
   } catch (error) {
-    console.log('CATCHED ERROR, RETURNING FALSE!!', error);
+    // Error occurred during fetch, assuming not public, returning false
     return false;
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,3 +48,52 @@ export async function checkImageApiHasCors() {
     return false;
   }
 }
+
+/**
+ * Check Object Public
+ * @param {Object} manifest - The IIIF manifest object
+ * @returns {boolean} true if object is public
+ */
+export async function checkObjectPublic(manifest) {
+  console.log('CHECKING IF OBJECT IS PUBLIC!!!!');
+  try {
+    // Get the first canvas from the manifest
+    if (!manifest || !manifest.items || manifest.items.length === 0) {
+      console.log('No items found in manifest, returning false');
+      return false;
+    }
+    
+    const firstCanvas = manifest.items[0];
+    if (!firstCanvas.items || firstCanvas.items.length === 0) {
+      console.log('No items found in first canvas, returning false');
+      return false;
+    }
+    
+    const firstAnnotationPage = firstCanvas.items[0];
+    if (!firstAnnotationPage.items || firstAnnotationPage.items.length === 0) {
+      console.log('No items found in first annotation page, returning false');
+      return false;
+    }
+    
+    const firstAnnotation = firstAnnotationPage.items[0];
+    const imageUrl = firstAnnotation.body.id || firstAnnotation.body['@id'];
+    
+    if (!imageUrl) {
+      console.log('No image URL found, returning false');
+      return false;
+    }
+    
+    let testImgResp = await fetch(imageUrl);
+    console.log("testImgResp.status", testImgResp.status);
+    if (testImgResp.status == 403 || testImgResp.status == 401) {
+      return false;
+    }
+    else { 
+      return true; 
+    };
+  } catch (error) {
+    console.log('CATCHED ERROR, RETURNING FALSE!!', error);
+    return false;
+  }
+}
+


### PR DESCRIPTION
**LTSVIEWER-366 No Restricted Downloads.**

---

**JIRA Ticket**: [LTSVIEWER-366)](https://at-harvard.atlassian.net/browse/LTSVIEWER-366)

# What does this Pull Request do?

This turns off the ability for users to download PDFs of Restricted Objects, even if they are logged in.

# How should this be tested?

A description of what steps someone could take to:

- Pull in the `LTSVIEWER-366-no-restricted-downloads` branch
- Run `npm install`
- Run `npm run serve` A browser window will pop open with Mirador at http://localhost:9000/
- There are 4 objects in Mirador. Check to see if you can download PDFs for each one. The correct functionality for each object is below
- `Rear elevation, design development drawing. Ink on tracing cloth`: PDF Download? **YES** (Public Single Page PTO)
- `Ukrainskaia SSR, 1975-1991, Americas, Europe, and Oceania Division`: PDF Download? **NO** (Public Single Image)
- `Rameau, Jean-Philippe, 1683-1764`: PDF Download: **YES** (Public Multi-Page PTO)
- `Bayo Oduneye's production of Wole Soyinka's Death and the king's horseman publication`: PDF Download: **NO** (Restricted PTO)

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz 
