### PR TITLE
LTSVIEWER-367 Add temporary link for restricted PDFs

### DIFF
--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -20,7 +20,6 @@ document.addEventListener("DOMContentLoaded", () => {
       
     ],
     miradorPdiiifPlugin: {
-      printServiceDomain:'https://iiif.lib.harvard.edu',
       nrsLookupDomain:'https://nrs.harvard.edu',
     },    
   };

--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -19,6 +19,10 @@ document.addEventListener("DOMContentLoaded", () => {
       },
       
     ],
+    miradorPdiiifPlugin: {
+      printServiceDomain:'https://iiif.lib.harvard.edu',
+      nrsLookupDomain:'https://nrs.harvard.edu',
+    },    
   };
 
   const plugins = [...Plugin];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-pdiiif-plugin",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-pdiiif-plugin",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "react-component"
   ],
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "mirador-pdiiif-plugin React component",
   "module": "dist/es/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import MiradorPDIIIFMenuItemPlugin from "./plugins/MiradorPDIIIFMenuItem";
 import MiradorPDIIIFDialogPlugin from "./plugins/MiradorPDIIIFDialog";
+import MiradorPDIIIFRestrictedDialogPlugin from "./plugins/MiradorPDIIIFRestrictedDialog";
 
-export { MiradorPDIIIFMenuItemPlugin, MiradorPDIIIFDialogPlugin };
+export { MiradorPDIIIFMenuItemPlugin, MiradorPDIIIFDialogPlugin, MiradorPDIIIFRestrictedDialogPlugin };
 
-export default [MiradorPDIIIFMenuItemPlugin, MiradorPDIIIFDialogPlugin];
+export default [MiradorPDIIIFMenuItemPlugin, MiradorPDIIIFDialogPlugin, MiradorPDIIIFRestrictedDialogPlugin];

--- a/src/plugins/MiradorPDIIIFRestrictedDialog.js
+++ b/src/plugins/MiradorPDIIIFRestrictedDialog.js
@@ -1,0 +1,465 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import Typography from "@material-ui/core/Typography";
+import FormControl from "@material-ui/core/FormControl";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio from "@material-ui/core/Radio";
+import TextField from "@material-ui/core/TextField";
+import Box from "@material-ui/core/Box";
+
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  closeDialog: () => {
+    dispatch({ type: "CLOSE_WINDOW_DIALOG", windowId });
+  },
+});
+
+const mapStateToProps = (state, { windowId }) => ({
+  open:
+    state.windowDialogs[windowId] &&
+    state.windowDialogs[windowId].openDialog === "PDIIIF_RESTRICTED",
+  containerId: state.config.id,
+  manifest: state.manifests[state.windows[windowId].manifestId],
+});
+
+/**
+ * PDIIIFRestrictedDialog - Dialog shown when object is not public
+ */
+export class PDIIIFRestrictedDialog extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      conversionType: 'current',
+      rangeFrom: '',
+      rangeTo: '',
+      rangeFromError: false,
+      rangeToError: false,
+      email: '',
+      emailError: false,
+      confirmationMessage: ''
+    };
+  }
+
+  handleDialogClose = () => {
+    this.setState({
+      confirmationMessage: '',
+      rangeFrom: '',
+      rangeTo: '',
+      email: '',
+      rangeFromError: false,
+      rangeToError: false,
+      emailError: false,
+      conversionType: 'current'
+    });
+    this.props.closeDialog();
+  };
+
+  handleConversionTypeChange = (event) => {
+    const { email } = this.state;
+    const newType = event.target.value;
+    
+    this.setState({ 
+      conversionType: newType,
+      confirmationMessage: '', // Clear confirmation when changing type
+      // Update email error based on new conversion type
+      emailError: !this.validateEmail(email) || (this.isEmailRequiredForType(newType) && email === '')
+    });
+  };
+
+  isEmailRequiredForType = (conversionType) => {
+    if (conversionType === 'entire') {
+      const maxCanvas = this.getMaxCanvasNumber();
+      return maxCanvas > 10;
+    } else if (conversionType === 'range') {
+      const { rangeFrom, rangeTo } = this.state;
+      const fromNum = parseInt(rangeFrom, 10);
+      const toNum = parseInt(rangeTo, 10);
+      
+      if (isNaN(fromNum) || isNaN(toNum)) return false;
+      
+      const rangeSize = toNum - fromNum + 1;
+      return rangeSize > 10;
+    }
+    
+    return false;
+  };
+
+  getMaxCanvasNumber = () => {
+    const { manifest } = this.props;
+    if (!manifest || !manifest.json || !manifest.json.items) {
+      return 999; // Default fallback if manifest not available
+    }
+    return manifest.json.items.length;
+  };
+
+  validateRange = (value) => {
+    const num = parseInt(value, 10);
+    const maxCanvas = this.getMaxCanvasNumber();
+    return value !== '' && (!isNaN(num) && num >= 1 && num <= maxCanvas);
+  };
+
+  validateRangeOrder = (fromValue, toValue) => {
+    if (fromValue === '' || toValue === '') return true; // Don't validate order if either is empty
+    const fromNum = parseInt(fromValue, 10);
+    const toNum = parseInt(toValue, 10);
+    return fromNum < toNum;
+  };
+
+  validateEmail = (email) => {
+    if (email === '') return true; // Email is optional by default
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  isEmailRequired = () => {
+    const { conversionType, rangeFrom, rangeTo } = this.state;
+    
+    if (conversionType === 'range') {
+      const fromNum = parseInt(rangeFrom, 10);
+      const toNum = parseInt(rangeTo, 10);
+      
+      if (isNaN(fromNum) || isNaN(toNum)) return false;
+      
+      const rangeSize = toNum - fromNum + 1;
+      return rangeSize > 10;
+    } else if (conversionType === 'entire') {
+      const maxCanvas = this.getMaxCanvasNumber();
+      return maxCanvas > 10;
+    }
+    
+    return false;
+  };
+
+  validateEmailRequired = () => {
+    const { email } = this.state;
+    if (!this.isEmailRequired()) return true; // Email not required
+    return email !== '' && this.validateEmail(email);
+  };
+
+  handleEmailChange = (event) => {
+    const value = event.target.value;
+    this.setState({
+      email: value,
+      emailError: !this.validateEmail(value) || (this.isEmailRequired() && value === '')
+    });
+  };
+
+  handleRangeFromChange = (event) => {
+    const value = event.target.value;
+    const { rangeTo, email } = this.state;
+    const isValidRange = this.validateRange(value);
+    const isValidOrder = this.validateRangeOrder(value, rangeTo);
+    
+    this.setState({ 
+      rangeFrom: value,
+      rangeFromError: value !== '' && (!isValidRange || !isValidOrder),
+      // Also update rangeTo error if order validation changes
+      rangeToError: rangeTo !== '' && (!this.validateRange(rangeTo) || !isValidOrder),
+      // Update email error if requirement changes
+      emailError: !this.validateEmail(email) || (this.isEmailRequired() && email === '')
+    });
+  };
+
+  handleRangeToChange = (event) => {
+    const value = event.target.value;
+    const { rangeFrom, email } = this.state;
+    const isValidRange = this.validateRange(value);
+    const isValidOrder = this.validateRangeOrder(rangeFrom, value);
+    
+    this.setState({ 
+      rangeTo: value,
+      rangeToError: value !== '' && (!isValidRange || !isValidOrder),
+      // Also update rangeFrom error if order validation changes
+      rangeFromError: rangeFrom !== '' && (!this.validateRange(rangeFrom) || !isValidOrder),
+      // Update email error if requirement changes
+      emailError: !this.validateEmail(email) || (this.isEmailRequired() && email === '')
+    });
+  };
+
+  getHelperText = (field) => {
+    const { rangeFrom, rangeTo, rangeFromError, rangeToError } = this.state;
+    const maxCanvas = this.getMaxCanvasNumber();
+    
+    if (field === 'from' && rangeFromError) {
+      if (!this.validateRange(rangeFrom)) {
+        return `Enter 1-${maxCanvas}`;
+      }
+      if (!this.validateRangeOrder(rangeFrom, rangeTo)) {
+        return "Must be < end";
+      }
+    }
+    
+    if (field === 'to' && rangeToError) {
+      if (!this.validateRange(rangeTo)) {
+        return `Enter 1-${maxCanvas}`;
+      }
+      if (!this.validateRangeOrder(rangeFrom, rangeTo)) {
+        return "Must be > start";
+      }
+    }
+    
+    return "";
+  };
+
+  handleConvertToPDF = async () => {
+    const { conversionType, rangeFrom, rangeTo, rangeFromError, rangeToError, email, emailError } = this.state;
+    
+    if (conversionType === 'current') {
+      // Open new tab for current page conversion
+      window.open('https://iiif.lib.harvard.edu/proxy/printpdf/502349283?n=1&printOpt=single', '_blank');
+    } else if (conversionType === 'range') {
+      // Validate range inputs and email requirement before proceeding
+      const emailRequired = this.isEmailRequired();
+      const isEmailValid = this.validateEmailRequired();
+      
+      if (rangeFrom === '' || rangeTo === '' || rangeFromError || rangeToError || !isEmailValid) {
+        // Set errors if fields are empty or invalid
+        this.setState({
+          rangeFromError: rangeFrom === '' || !this.validateRange(rangeFrom) || !this.validateRangeOrder(rangeFrom, rangeTo),
+          rangeToError: rangeTo === '' || !this.validateRange(rangeTo) || !this.validateRangeOrder(rangeFrom, rangeTo),
+          emailError: !this.validateEmail(email) || (emailRequired && email === '')
+        });
+        return; // Don't proceed if validation fails
+      }
+      
+      const fromNum = parseInt(rangeFrom, 10);
+      const toNum = parseInt(rangeTo, 10);
+      const rangeSize = toNum - fromNum + 1;
+      
+      // Build the URL
+      const url = `https://iiif.lib.harvard.edu/proxy/printpdf/502349283?printOpt=range&start=${rangeFrom}&end=${rangeTo}&email=${encodeURIComponent(email)}`;
+      
+      if (rangeSize > 10) {
+        // For large requests, send background GET request and show confirmation
+        try {
+          await fetch(url, { method: 'GET' });
+          this.setState({
+            confirmationMessage: `PDF sent to ${email}`
+          });
+          // Don't close dialog immediately for large requests
+          return;
+        } catch (error) {
+          console.error('Error sending PDF request:', error);
+          // Fall back to opening in new tab if fetch fails
+          window.open(url, '_blank');
+        }
+      } else {
+        // For small requests, open in new tab as before
+        window.open(url, '_blank');
+      }
+    } else if (conversionType === 'entire') {
+      // Convert entire document: start=1, end=total canvases
+      const maxCanvas = this.getMaxCanvasNumber();
+      const rangeSize = maxCanvas; // 1 to maxCanvas = maxCanvas pages
+      
+      // Check if email is required (when total pages > 10)
+      const emailRequired = rangeSize > 10;
+      const isEmailValid = !emailRequired || (email !== '' && this.validateEmail(email));
+      
+      if (emailRequired && !isEmailValid) {
+        // Set email error if required but not provided or invalid
+        this.setState({
+          emailError: email === '' || !this.validateEmail(email)
+        });
+        return; // Don't proceed if validation fails
+      }
+      
+      // Build the URL for entire document
+      const url = `https://iiif.lib.harvard.edu/proxy/printpdf/502349283?printOpt=range&start=1&end=${maxCanvas}&email=${encodeURIComponent(email)}`;
+      
+      if (rangeSize > 10) {
+        // For large documents, send background GET request and show confirmation
+        try {
+          await fetch(url, { method: 'GET' });
+          this.setState({
+            confirmationMessage: `PDF sent to ${email}`
+          });
+          // Don't close dialog immediately for large requests
+          return;
+        } catch (error) {
+          console.error('Error sending PDF request:', error);
+          // Fall back to opening in new tab if fetch fails
+          window.open(url, '_blank');
+        }
+      } else {
+        // For small documents, open in new tab
+        window.open(url, '_blank');
+      }
+    } else {
+      // Fallback for any other conversion types
+      console.log('Convert to PDF:', { conversionType, rangeFrom, rangeTo });
+    }
+    
+    // Close dialog after conversion request (except for large range requests)
+    this.props.closeDialog();
+  };
+
+  /**
+   * Returns the rendered component
+   */
+  render() {
+    const {
+      classes,
+      closeDialog,
+      containerId,
+      open,
+    } = this.props;
+
+    if (!open) return null;
+
+    return (
+      <Dialog
+        container={document.querySelector(`#${containerId} .mirador-viewer`)}
+        disableEnforceFocus
+        onClose={this.handleDialogClose}
+        open={open}
+        scroll="paper"
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle disableTypography className={classes.h2}>
+          <Typography variant="h2">PDF Request</Typography>
+        </DialogTitle>
+        <DialogContent>
+          {this.state.confirmationMessage && (
+            <Box mb={2} p={2} bgcolor="success.main" color="white" borderRadius={1}>
+              <Typography variant="body1">
+                {this.state.confirmationMessage}
+              </Typography>
+            </Box>
+          )}
+          <DialogContentText>
+            Use this form to request one or more pages in PDF format for printing or saving. Requests for 10 pages or less will be delivered directly to your browser. For larger requests, enter your email below and we will send a link to the PDF when the conversion is complete. The link will be valid for 7 days.
+          </DialogContentText>
+          <DialogContentText>
+            <strong>Tips on requesting a PDF:</strong>
+            <br />
+            • The PDF conversion rate is approx. 10 pages per minute. Large requests can take an hour or more to process.
+            <br />
+            • To request a range of pages, use page sequence numbers rather than printed page numbers. Sequence numbers appear in parentheses – e.g., (seq. 1); look for them in the left-hand table of contents or mouse over the page thumbnail at the bottom of the viewer.
+          </DialogContentText>
+          
+          <Box mt={3}>
+            <FormControl component="fieldset">
+              <RadioGroup
+                value={this.state.conversionType}
+                onChange={this.handleConversionTypeChange}
+              >
+                <FormControlLabel
+                  value="current"
+                  control={<Radio />}
+                  label="Convert the current page"
+                />
+                <FormControlLabel
+                  value="range"
+                  control={<Radio />}
+                  label={
+                    <Box display="flex" alignItems="center" flexWrap="wrap">
+                      <span>Convert a range: from seq.&nbsp;</span>
+                      <TextField
+                        size="small"
+                        variant="outlined"
+                        value={this.state.rangeFrom}
+                        onChange={this.handleRangeFromChange}
+                        disabled={this.state.conversionType !== 'range'}
+                        error={this.state.rangeFromError}
+                        helperText={this.getHelperText('from')}
+                        inputProps={{ min: 1, max: this.getMaxCanvasNumber(), pattern: "[0-9]*" }}
+                        style={{ width: '80px', margin: '0 8px' }}
+                      />
+                      <span>&nbsp;to seq.&nbsp;</span>
+                      <TextField
+                        size="small"
+                        variant="outlined"
+                        value={this.state.rangeTo}
+                        onChange={this.handleRangeToChange}
+                        disabled={this.state.conversionType !== 'range'}
+                        error={this.state.rangeToError}
+                        helperText={this.getHelperText('to')}
+                        inputProps={{ min: 1, max: this.getMaxCanvasNumber(), pattern: "[0-9]*" }}
+                        style={{ width: '80px', margin: '0 8px' }}
+                      />
+                    </Box>
+                  }
+                />
+                <FormControlLabel
+                  value="entire"
+                  control={<Radio />}
+                  label="Convert entire document"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Box>
+          
+          <Box mt={3}>
+            <Typography variant="body2" style={{ marginBottom: '8px' }}>
+              For requests of more than 10 pages, enter your email address so that we can send a link to the PDF when the conversion is complete:
+            </Typography>
+            <TextField
+              fullWidth
+              variant="outlined"
+              label={this.isEmailRequired() ? "Email address (required)" : "Email address"}
+              value={this.state.email}
+              onChange={this.handleEmailChange}
+              error={this.state.emailError}
+              helperText={
+                this.state.emailError 
+                  ? (this.isEmailRequired() && this.state.email === '') 
+                    ? "Email is required for requests of more than 10 pages"
+                    : "Please enter a valid email address"
+                  : ""
+              }
+              placeholder="example@email.com"
+              required={this.isEmailRequired()}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.handleDialogClose} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={this.handleConvertToPDF} color="primary" variant="contained">
+            Convert to PDF
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+PDIIIFRestrictedDialog.propTypes = {
+  classes: PropTypes.shape({
+    h2: PropTypes.string,
+  }).isRequired,
+  closeDialog: PropTypes.func.isRequired,
+  containerId: PropTypes.string.isRequired,
+  manifest: PropTypes.object,
+  open: PropTypes.bool,
+  windowId: PropTypes.string.isRequired,
+};
+
+PDIIIFRestrictedDialog.defaultProps = {
+  open: false,
+};
+
+const styles = () => ({
+  h2: {
+    paddingBottom: 0,
+  },
+});
+
+export default {
+  target: "Window",
+  mode: "add",
+  name: "PDIIIFRestrictedDialog",
+  component: withStyles(styles)(PDIIIFRestrictedDialog),
+  mapDispatchToProps,
+  mapStateToProps,
+};

--- a/src/plugins/MiradorPDIIIFRestrictedDialog.js
+++ b/src/plugins/MiradorPDIIIFRestrictedDialog.js
@@ -6,14 +6,7 @@ import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
-import DialogContentText from "@material-ui/core/DialogContentText";
 import Typography from "@material-ui/core/Typography";
-import FormControl from "@material-ui/core/FormControl";
-import RadioGroup from "@material-ui/core/RadioGroup";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Radio from "@material-ui/core/Radio";
-import TextField from "@material-ui/core/TextField";
-import Box from "@material-ui/core/Box";
 
 const mapDispatchToProps = (dispatch, { windowId }) => ({
   closeDialog: () => {
@@ -27,7 +20,6 @@ const mapStateToProps = (state, { windowId }) => ({
     state.windowDialogs[windowId].openDialog === "PDIIIF_RESTRICTED",
   containerId: state.config.id,
   manifest: state.manifests[state.windows[windowId].manifestId],
-  printServiceHost: state.config.miradorPdiiifPlugin?.printServiceDomain,
   nrsLookupHost: state.config.miradorPdiiifPlugin?.nrsLookupDomain,
 });
 
@@ -37,315 +29,40 @@ const mapStateToProps = (state, { windowId }) => ({
 export class PDIIIFRestrictedDialog extends Component {
   constructor(props) {
     super(props);
-    const { printServiceHost, nrsLookupHost } = this.props;
+    const { nrsLookupHost } = this.props;
     this.state = {
-      conversionType: 'current',
-      rangeFrom: '',
-      rangeTo: '',
-      rangeFromError: false,
-      rangeToError: false,
-      email: '',
-      emailError: false,
-      confirmationMessage: '',
-      printServiceHost: printServiceHost,
       nrsLookupHost: nrsLookupHost,
     };
   }
 
   handleDialogClose = () => {
-    this.setState({
-      confirmationMessage: '',
-      rangeFrom: '',
-      rangeTo: '',
-      email: '',
-      rangeFromError: false,
-      rangeToError: false,
-      emailError: false,
-      conversionType: 'current'
-    });
     this.props.closeDialog();
   };
 
-  handleConversionTypeChange = (event) => {
-    const { email } = this.state;
-    const newType = event.target.value;
+  getOldViewerUrl = () => {
+    const { manifest, nrsLookupHost } = this.props;
     
-    this.setState({ 
-      conversionType: newType,
-      confirmationMessage: '', // Clear confirmation when changing type
-      // Update email error based on new conversion type
-      emailError: !this.validateEmail(email) || (this.isEmailRequiredForType(newType) && email === '')
-    });
-  };
-
-  isEmailRequiredForType = (conversionType) => {
-    if (conversionType === 'entire') {
-      const maxCanvas = this.getMaxCanvasNumber();
-      return maxCanvas > 10;
-    } else if (conversionType === 'range') {
-      const { rangeFrom, rangeTo } = this.state;
-      const fromNum = parseInt(rangeFrom, 10);
-      const toNum = parseInt(rangeTo, 10);
-      
-      if (isNaN(fromNum) || isNaN(toNum)) return false;
-      
-      const rangeSize = toNum - fromNum + 1;
-      return rangeSize > 10;
-    }
-    
-    return false;
-  };
-
-  getMaxCanvasNumber = () => {
-    const { manifest } = this.props;
-    if (!manifest || !manifest.json || !manifest.json.items) {
-      return 999; // Default fallback if manifest not available
-    }
-    return manifest.json.items.length;
-  };
-
-  validateRange = (value) => {
-    const num = parseInt(value, 10);
-    const maxCanvas = this.getMaxCanvasNumber();
-    return value !== '' && (!isNaN(num) && num >= 1 && num <= maxCanvas);
-  };
-
-  validateRangeOrder = (fromValue, toValue) => {
-    if (fromValue === '' || toValue === '') return true; // Don't validate order if either is empty
-    const fromNum = parseInt(fromValue, 10);
-    const toNum = parseInt(toValue, 10);
-    return fromNum < toNum;
-  };
-
-  validateEmail = (email) => {
-    if (email === '') return true; // Email is optional by default
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  isEmailRequired = () => {
-    const { conversionType, rangeFrom, rangeTo } = this.state;
-    
-    if (conversionType === 'range') {
-      const fromNum = parseInt(rangeFrom, 10);
-      const toNum = parseInt(rangeTo, 10);
-      
-      if (isNaN(fromNum) || isNaN(toNum)) return false;
-      
-      const rangeSize = toNum - fromNum + 1;
-      return rangeSize > 10;
-    } else if (conversionType === 'entire') {
-      const maxCanvas = this.getMaxCanvasNumber();
-      return maxCanvas > 10;
-    }
-    
-    return false;
-  };
-
-  validateEmailRequired = () => {
-    const { email } = this.state;
-    if (!this.isEmailRequired()) return true; // Email not required
-    return email !== '' && this.validateEmail(email);
-  };
-
-  handleEmailChange = (event) => {
-    const value = event.target.value;
-    this.setState({
-      email: value,
-      emailError: !this.validateEmail(value) || (this.isEmailRequired() && value === '')
-    });
-  };
-
-  handleRangeFromChange = (event) => {
-    const value = event.target.value;
-    const { rangeTo, email } = this.state;
-    const isValidRange = this.validateRange(value);
-    const isValidOrder = this.validateRangeOrder(value, rangeTo);
-    
-    this.setState({ 
-      rangeFrom: value,
-      rangeFromError: value !== '' && (!isValidRange || !isValidOrder),
-      // Also update rangeTo error if order validation changes
-      rangeToError: rangeTo !== '' && (!this.validateRange(rangeTo) || !isValidOrder),
-      // Update email error if requirement changes
-      emailError: !this.validateEmail(email) || (this.isEmailRequired() && email === '')
-    });
-  };
-
-  handleRangeToChange = (event) => {
-    const value = event.target.value;
-    const { rangeFrom, email } = this.state;
-    const isValidRange = this.validateRange(value);
-    const isValidOrder = this.validateRangeOrder(rangeFrom, value);
-    
-    this.setState({ 
-      rangeTo: value,
-      rangeToError: value !== '' && (!isValidRange || !isValidOrder),
-      // Also update rangeFrom error if order validation changes
-      rangeFromError: rangeFrom !== '' && (!this.validateRange(rangeFrom) || !isValidOrder),
-      // Update email error if requirement changes
-      emailError: !this.validateEmail(email) || (this.isEmailRequired() && email === '')
-    });
-  };
-
-  getHelperText = (field) => {
-    const { rangeFrom, rangeTo, rangeFromError, rangeToError } = this.state;
-    const maxCanvas = this.getMaxCanvasNumber();
-    
-    if (field === 'from' && rangeFromError) {
-      if (!this.validateRange(rangeFrom)) {
-        return `Enter 1-${maxCanvas}`;
-      }
-      if (!this.validateRangeOrder(rangeFrom, rangeTo)) {
-        return "Must be < end";
-      }
-    }
-    
-    if (field === 'to' && rangeToError) {
-      if (!this.validateRange(rangeTo)) {
-        return `Enter 1-${maxCanvas}`;
-      }
-      if (!this.validateRangeOrder(rangeFrom, rangeTo)) {
-        return "Must be > start";
-      }
-    }
-    
-    return "";
-  };
-
-  handleConvertToPDF = async () => {
-    const { conversionType, rangeFrom, rangeTo, rangeFromError, rangeToError, email, emailError, printServiceHost, nrsLookupHost } = this.state;
-
-    // Extract URN from manifest ID
-    let urn = '';
-    const { manifest } = this.props;
     if (manifest && manifest.json && manifest.json.id) {
       const manifestId = manifest.json.id;
+      
+      // Extract host from manifest URL
+      let host = nrsLookupHost || 'https://nrs.harvard.edu'; // Default fallback
+      
+      // Check if manifest URL starts with "https://nrs" and ends with "harvard.edu"
+      const hostMatch = manifestId.match(/^(https:\/\/nrs[^\/]*harvard\.edu)/);
+      if (hostMatch) {
+        host = hostMatch[1];
+      }
+      
       // Extract URN from URL like https://nrs.harvard.edu/URN-3:FHCL.HOUGH:105813588:MANIFEST:3
-      const match = manifestId.match(/https?:\/\/[^\/]+\/([^:]+:[^:]+:[^:]+):/);
-      if (match) {
-        urn = match[1]; // This would be URN-3:FHCL.HOUGH:105813588
+      const urnMatch = manifestId.match(/https?:\/\/[^\/]+\/([^:]+:[^:]+:[^:]+):/);
+      if (urnMatch) {
+        const urn = urnMatch[1]; // This would be URN-3:FHCL.HOUGH:105813588
+        return `${host}/${urn}:MIRADOR:2`;
       }
     }
     
-    // Get app_id from lookup API
-    let appId = '';
-    if (urn) {
-      try {
-        const lookupResponse = await fetch(`${nrsLookupHost}/api/resolve/${urn}`);
-        if (lookupResponse.ok) {
-          const lookupData = await lookupResponse.json();
-          appId = lookupData.app_id || '';
-        } else {
-          console.error('Lookup API response not OK:', lookupResponse.status, lookupResponse.statusText);
-        }
-      } catch (error) {
-        console.error('Error fetching app_id from lookup API:', error);
-      }
-    } else {
-      console.error('No URN extracted from manifest ID');
-    }
-    
-    if (conversionType === 'current') {
-      // Open new tab for current page conversion
-      window.open(`${printServiceHost}/proxy/printpdf/${appId}?n=1&printOpt=single`, '_blank');
-    } else if (conversionType === 'range') {
-      // Validate range inputs and email requirement before proceeding
-      const emailRequired = this.isEmailRequired();
-      const isEmailValid = this.validateEmailRequired();
-      
-      if (rangeFrom === '' || rangeTo === '' || rangeFromError || rangeToError || !isEmailValid) {
-        // Set errors if fields are empty or invalid
-        this.setState({
-          rangeFromError: rangeFrom === '' || !this.validateRange(rangeFrom) || !this.validateRangeOrder(rangeFrom, rangeTo),
-          rangeToError: rangeTo === '' || !this.validateRange(rangeTo) || !this.validateRangeOrder(rangeFrom, rangeTo),
-          emailError: !this.validateEmail(email) || (emailRequired && email === '')
-        });
-        return; // Don't proceed if validation fails
-      }
-      
-      const fromNum = parseInt(rangeFrom, 10);
-      const toNum = parseInt(rangeTo, 10);
-      const rangeSize = toNum - fromNum + 1;
-      
-      // Build the URL
-      const url = `${printServiceHost}/proxy/printpdf/${appId}?printOpt=range&start=${rangeFrom}&end=${rangeTo}&email=${encodeURIComponent(email)}`;
-      
-      if (rangeSize > 10) {
-        // For large requests, send background GET request and show confirmation
-        try {
-          await fetch(url, { 
-            method: 'GET',
-            credentials: 'include'
-          });
-          this.setState({
-            confirmationMessage: `PDF sent to ${email}`
-          });
-          // Don't close dialog immediately for large requests
-          return;
-        } catch (error) {
-          console.error('Error sending PDF request:', error);
-          // Fall back to opening in new tab if fetch fails
-          window.open(url, '_blank');
-        }
-      } else {
-        // For small requests, open in new tab as before
-        window.open(url, '_blank');
-      }
-    } else if (conversionType === 'entire') {
-      // Convert entire document: start=1, end=total canvases
-      const maxCanvas = this.getMaxCanvasNumber();
-      const rangeSize = maxCanvas; // 1 to maxCanvas = maxCanvas pages
-      
-      // Check if email is required (when total pages > 10)
-      const emailRequired = rangeSize > 10;
-      const isEmailValid = !emailRequired || (email !== '' && this.validateEmail(email));
-      
-      if (emailRequired && !isEmailValid) {
-        // Set email error if required but not provided or invalid
-        this.setState({
-          emailError: email === '' || !this.validateEmail(email)
-        });
-        return; // Don't proceed if validation fails
-      }
-      
-      // Build the URL for entire document
-      const url = `${printServiceHost}/proxy/printpdf/${appId}?printOpt=range&start=1&end=${maxCanvas}&email=${encodeURIComponent(email)}`;
-      
-      if (rangeSize > 10) {
-        // For large documents, send background GET request and show confirmation
-        try {
-          const response = await fetch(url, { 
-            method: 'GET',
-            credentials: 'include'
-          });
-          if (response.ok) {
-            this.setState({
-              confirmationMessage: `PDF sent to ${email}`
-            });
-            // Don't close dialog immediately for large requests
-            return;
-          } else {
-            const errorText = await response.text();
-            console.error('Server error response:', errorText);
-            throw new Error(`Server returned ${response.status}: ${response.statusText}`);
-          }
-        } catch (error) {
-          console.error('Error sending PDF request:', error);
-          // Fall back to opening in new tab if fetch fails
-          window.open(url, '_blank');
-        }
-      } else {
-        // For small documents, open in new tab
-        window.open(url, '_blank');
-      }
-    } else {
-      // Fallback for any other conversion types
-      console.log('Convert to PDF:', { conversionType, rangeFrom, rangeTo });
-    }
-    
-    // Close dialog after conversion request (except for large range requests)
-    this.props.closeDialog();
+    return '#'; // Fallback if URN cannot be extracted
   };
 
   /**
@@ -375,105 +92,18 @@ export class PDIIIFRestrictedDialog extends Component {
           <Typography variant="h2">PDF Request</Typography>
         </DialogTitle>
         <DialogContent>
-          {this.state.confirmationMessage && (
-            <Box mb={2} p={2} bgcolor="success.main" color="white" borderRadius={1}>
-              <Typography variant="body1">
-                {this.state.confirmationMessage}
-              </Typography>
-            </Box>
-          )}
-          <DialogContentText>
-            Use this form to request one or more pages in PDF format for printing or saving. Requests for 10 pages or less will be delivered directly to your browser. For larger requests, enter your email below and we will send a link to the PDF when the conversion is complete. The link will be valid for 7 days.
-          </DialogContentText>
-          <DialogContentText>
-            <strong>Tips on requesting a PDF:</strong>
-            <br />
-            • The PDF conversion rate is approx. 10 pages per minute. Large requests can take an hour or more to process.
-            <br />
-            • To request a range of pages, use page sequence numbers rather than printed page numbers. Sequence numbers appear in parentheses – e.g., (seq. 1); look for them in the left-hand table of contents or mouse over the page thumbnail at the bottom of the viewer.
-          </DialogContentText>
-          
-          <Box mt={3}>
-            <FormControl component="fieldset">
-              <RadioGroup
-                value={this.state.conversionType}
-                onChange={this.handleConversionTypeChange}
-              >
-                <FormControlLabel
-                  value="current"
-                  control={<Radio />}
-                  label="Convert the current page"
-                />
-                <FormControlLabel
-                  value="range"
-                  control={<Radio />}
-                  label={
-                    <Box display="flex" alignItems="center" flexWrap="wrap">
-                      <span>Convert a range: from seq.&nbsp;</span>
-                      <TextField
-                        size="small"
-                        variant="outlined"
-                        value={this.state.rangeFrom}
-                        onChange={this.handleRangeFromChange}
-                        disabled={this.state.conversionType !== 'range'}
-                        error={this.state.rangeFromError}
-                        helperText={this.getHelperText('from')}
-                        inputProps={{ min: 1, max: this.getMaxCanvasNumber(), pattern: "[0-9]*" }}
-                        style={{ width: '80px', margin: '0 8px' }}
-                      />
-                      <span>&nbsp;to seq.&nbsp;</span>
-                      <TextField
-                        size="small"
-                        variant="outlined"
-                        value={this.state.rangeTo}
-                        onChange={this.handleRangeToChange}
-                        disabled={this.state.conversionType !== 'range'}
-                        error={this.state.rangeToError}
-                        helperText={this.getHelperText('to')}
-                        inputProps={{ min: 1, max: this.getMaxCanvasNumber(), pattern: "[0-9]*" }}
-                        style={{ width: '80px', margin: '0 8px' }}
-                      />
-                    </Box>
-                  }
-                />
-                <FormControlLabel
-                  value="entire"
-                  control={<Radio />}
-                  label="Convert entire document"
-                />
-              </RadioGroup>
-            </FormControl>
-          </Box>
-          
-          <Box mt={3}>
-            <Typography variant="body2" style={{ marginBottom: '8px' }}>
-              For requests of more than 10 pages, enter your email address so that we can send a link to the PDF when the conversion is complete:
-            </Typography>
-            <TextField
-              fullWidth
-              variant="outlined"
-              label={this.isEmailRequired() ? "Email address (required)" : "Email address"}
-              value={this.state.email}
-              onChange={this.handleEmailChange}
-              error={this.state.emailError}
-              helperText={
-                this.state.emailError 
-                  ? (this.isEmailRequired() && this.state.email === '') 
-                    ? "Email is required for requests of more than 10 pages"
-                    : "Please enter a valid email address"
-                  : ""
-              }
-              placeholder="example@email.com"
-              required={this.isEmailRequired()}
-            />
-          </Box>
+          <Typography variant="body1" style={{ marginBottom: '16px' }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </Typography>
+          <Typography variant="body1">
+            <a href={this.getOldViewerUrl()} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', color: '#1976d2' }}>
+              View this object in the old Viewer to download the PDF.
+            </a>
+          </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={this.handleDialogClose} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={this.handleConvertToPDF} color="primary" variant="contained">
-            Convert to PDF
+          <Button onClick={this.handleDialogClose} color="primary" variant="contained">
+            Close
           </Button>
         </DialogActions>
       </Dialog>
@@ -490,13 +120,11 @@ PDIIIFRestrictedDialog.propTypes = {
   manifest: PropTypes.object,
   open: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
-  printServiceHost: PropTypes.string,
   nrsLookupHost: PropTypes.string,
 };
 
 PDIIIFRestrictedDialog.defaultProps = {
   open: false,
-  printServiceHost: null,
   nrsLookupHost: null,
 };
 

--- a/src/plugins/MiradorPDIIIFRestrictedDialog.js
+++ b/src/plugins/MiradorPDIIIFRestrictedDialog.js
@@ -89,16 +89,16 @@ export class PDIIIFRestrictedDialog extends Component {
         maxWidth="xs"
       >
         <DialogTitle disableTypography className={classes.h2}>
-          <Typography variant="h2">PDF Request</Typography>
+          <Typography variant="h2">PDF Download</Typography>
         </DialogTitle>
         <DialogContent>
           <Typography variant="body1" style={{ marginBottom: '16px' }}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Services for restricted items such as PDF generation are currently unavailable in the latest version of the Viewer.
           </Typography>
           <Typography variant="body1">
             <a href={this.getOldViewerUrl()} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', color: '#1976d2' }}>
-              View this object in the old Viewer to download the PDF.
-            </a>
+              View this item in the old Viewer
+            </a> to download the PDF.
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/tests/MiradorPDIIIFMenuItem.test.js
+++ b/tests/MiradorPDIIIFMenuItem.test.js
@@ -38,29 +38,33 @@ describe("PDF menu item", () => {
   });
 
   it("Should display 'PDF Restricted' for restricted objects", async () => {
-    // Create a component with showMenuItem=true and objectPublic=false in state
+    // Create a wrapper component to set internal state
     const TestComponent = () => {
-      const [component] = React.useState(() => {
-        const comp = new MiradorPDIIIFMenuItemPlugin.component({
-          manifest: {},
-          allowPdfDownload: false,
-          setEstimatedSize: () => {},
-          setAllowPdfDownload: () => {},
-          canvasGroupings: [],
-        });
-        
-        // Set the state to simulate a restricted object that should show the menu item
-        comp.state = {
-          ...comp.state,
-          hasChecked: true,
-          showMenuItem: true,
-          objectPublic: false,
-        };
-        
-        return comp;
+      const [stateOverride, setStateOverride] = React.useState({
+        hasChecked: true,
+        showMenuItem: true,
+        objectPublic: false,
       });
       
-      return component.render();
+      // Create ref to component instance
+      const componentRef = React.useRef();
+      
+      React.useEffect(() => {
+        if (componentRef.current) {
+          componentRef.current.setState(stateOverride);
+        }
+      }, [stateOverride]);
+      
+      return (
+        <MiradorPDIIIFMenuItemPlugin.component
+          ref={componentRef}
+          manifest={{}}
+          allowPdfDownload={false}
+          setEstimatedSize={() => {}}
+          setAllowPdfDownload={() => {}}
+          canvasGroupings={[]}
+        />
+      );
     };
 
     const { getByText } = render(<TestComponent />);

--- a/tests/MiradorPDIIIFMenuItem.test.js
+++ b/tests/MiradorPDIIIFMenuItem.test.js
@@ -36,4 +36,34 @@ describe("PDF menu item", () => {
     );
     await waitFor(() => getByText("PDF Unavailable"));
   });
+
+  it("Should display 'PDF Restricted' for restricted objects", async () => {
+    // Create a component with showMenuItem=true and objectPublic=false in state
+    const TestComponent = () => {
+      const [component] = React.useState(() => {
+        const comp = new MiradorPDIIIFMenuItemPlugin.component({
+          manifest: {},
+          allowPdfDownload: false,
+          setEstimatedSize: () => {},
+          setAllowPdfDownload: () => {},
+          canvasGroupings: [],
+        });
+        
+        // Set the state to simulate a restricted object that should show the menu item
+        comp.state = {
+          ...comp.state,
+          hasChecked: true,
+          showMenuItem: true,
+          objectPublic: false,
+        };
+        
+        return comp;
+      });
+      
+      return component.render();
+    };
+
+    const { getByText } = render(<TestComponent />);
+    await waitFor(() => getByText("PDF Restricted"));
+  });
 });

--- a/tests/MiradorPDIIIFRestrictedDialog.test.js
+++ b/tests/MiradorPDIIIFRestrictedDialog.test.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MiradorPDIIIFRestrictedDialogPlugin } from "../src";
+
+describe("PDF restricted dialog", () => {
+  it("Should render the restricted dialog when open", () => {
+    const { getByText } = render(
+      <MiradorPDIIIFRestrictedDialogPlugin.component
+        open={true}
+        closeDialog={() => {}}
+        containerId="test-container"
+        windowId="test-window"
+        classes={{ h2: "" }}
+      />
+    );
+    expect(getByText("PDF Download Restricted")).toBeInTheDocument();
+    expect(getByText("This document is restricted and cannot be downloaded as a PDF. Please contact the institution for access to this material.")).toBeInTheDocument();
+  });
+
+  it("Should not render when closed", () => {
+    const { container } = render(
+      <MiradorPDIIIFRestrictedDialogPlugin.component
+        open={false}
+        closeDialog={() => {}}
+        containerId="test-container"
+        windowId="test-window"
+        classes={{ h2: "" }}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/MiradorPDIIIFRestrictedDialog.test.js
+++ b/tests/MiradorPDIIIFRestrictedDialog.test.js
@@ -13,8 +13,9 @@ describe("PDF restricted dialog", () => {
         classes={{ h2: "" }}
       />
     );
-    expect(getByText("PDF Download Restricted")).toBeInTheDocument();
-    expect(getByText("This document is restricted and cannot be downloaded as a PDF. Please contact the institution for access to this material.")).toBeInTheDocument();
+    expect(getByText("PDF Request")).toBeInTheDocument();
+    expect(getByText(/Lorem ipsum dolor sit amet/)).toBeInTheDocument();
+    expect(getByText("View this object in the old Viewer to download the PDF.")).toBeInTheDocument();
   });
 
   it("Should not render when closed", () => {

--- a/tests/MiradorPDIIIFRestrictedDialog.test.js
+++ b/tests/MiradorPDIIIFRestrictedDialog.test.js
@@ -13,9 +13,8 @@ describe("PDF restricted dialog", () => {
         classes={{ h2: "" }}
       />
     );
-    expect(getByText("PDF Request")).toBeInTheDocument();
-    expect(getByText(/Lorem ipsum dolor sit amet/)).toBeInTheDocument();
-    expect(getByText("View this object in the old Viewer to download the PDF.")).toBeInTheDocument();
+    expect(getByText("PDF Download")).toBeInTheDocument();
+    expect(getByText("View this item in the old Viewer")).toBeInTheDocument();
   });
 
   it("Should not render when closed", () => {


### PR DESCRIPTION
**LTSVIEWER-367 Add temporary link for restricted PDFs.**

---

**JIRA Ticket**: [LTSVIEWER-367](https://at-harvard.atlassian.net/browse/LTSVIEWER-367)

# What does this Pull Request do?

This update opens a different modal window for restricted PDFs (regardless of if you are logged in or not). Inside the new modal window it includes a link to the same item in the old Mirador 2 Viewer so users can download the PDF through the PDS PDF download service.

# How should this be tested?

A description of what steps someone could take to:

- Pull in the code from the `LTSVIEWER-367-temporary-link` branch
- Run `npm install`
- Run `npm run test` to confirm that tests are passing
- Run `npm run serve` to open the example plugin in a browser window.
- Confirm that public objects are still using pdiiif. (Downloads in the browser in new Viewer)
- Confirm that restricted objects open a modal with a link to the same object in Mirador 2.
- The examples in the plugin include one restricted object in production by default (Bayo Oduneye's production of Wole Soyinka's Death and the king's horseman publication by Deapartment of theatre arts). More can be tested (including from QA and Dev environments) using the plus sign (+) in Viewer to add additional objects by manifest URL (Use the NRS URN URLs when testing. For example: https://nrs-qa.lib.harvard.edu/URN-3:DIV.LIB:100130179:MANIFEST:3)

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? Yes
- integration tests? No

# Interested parties

@enriquediaz 


[LTSVIEWER-367]: https://at-harvard.atlassian.net/browse/LTSVIEWER-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ